### PR TITLE
[hotfix/frontend-49/App.js] App.js 레이아웃 컴포넌트 import 중복 수정

### DIFF
--- a/senials_frontend/src/App.js
+++ b/senials_frontend/src/App.js
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react";
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 // 컴포넌트
-import Layout from './layouts/Layout.js';
+import MainPage from './pages/mainpage/MainPage.js';
+
 import PartyDetail from './pages/party/PartyDetail.js';
 import Board from './pages/party/Board.js';
 import BoardOverview from './pages/party/BoardOverview.js';
@@ -25,10 +26,6 @@ import HobbyBoardPost from './pages/hobby/hobby-board-post';
 import HobbyDetailPost from './pages/hobby/HobbyDetailPost.js';
 import HobbyReviewGet from './pages/hobby/HobbyReviewGet';
 import HobbyReviewModify from './pages/hobby/HobbyReviewModify';
-
-// 컴포넌트
-import Layout from './layouts/Layout.js';
-import MainPage from './pages/mainpage/MainPage.js';
 
 function App() {
     return (


### PR DESCRIPTION
## 이슈
- #49 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/1f6cd81b-be4f-4660-9ce1-967bdd7ce0af)



## 📝작업 내용
- 레이아웃 컴포넌트 중복호출 제거


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/5a4f1677-ef8c-499c-8464-f70f5fb3d2dd)
![image](https://github.com/user-attachments/assets/926c2f93-5530-43a4-8a73-aa3f85a23605)
