### PR TITLE
[feature/frontend-115/hobbyboard_suggesthobby/request-api] 취미 게시판 맞춤형 취미 추천 페이지 로직 설정 #115

### DIFF
--- a/senials_frontend/src/pages/suggestHobby/SuggestHobby.js
+++ b/senials_frontend/src/pages/suggestHobby/SuggestHobby.js
@@ -1,15 +1,21 @@
-import React from 'react';
+import React,{useState} from 'react';
 import style from './SuggestHobby.module.css';
 import { useNavigate } from 'react-router-dom';
 
 function SuggestHobbyGet() {
     const navigate=useNavigate();
 
-    // 맞춤형 취미 추천 입력후 제출, 결과 페이지 이동 이벤트
-    const linkSubmitHobby=()=>{
-        navigate('/suggest-hobby-result');
-    }
+    //맞춤형 취미를 위해 넘겨줄 데이터값 state
+    const [hobbyAbility, setHobbyAbility] = useState("");
+    const [hobbyBudget, setHobbyBudget] = useState("");
+    const [hobbyLevel, setHobbyLevel] = useState("");
+    const [hobbyTendency, setHobbyTendency] = useState("");
 
+    // 맞춤형 취미 추천 입력후 제출, 결과 페이지 이동 이벤트, 쿼리스트링
+    const linkSubmitHobby=(e)=>{
+        e.preventDefault(); 
+        navigate(`/suggest-hobby-result?hobbyAbility=${hobbyAbility}&hobbyBudget=${hobbyBudget}&hobbyLevel=${hobbyLevel}&hobbyTendency=${hobbyTendency}`);
+    };
 
     return (
         <>
@@ -18,44 +24,45 @@ function SuggestHobbyGet() {
                 <div className={style.title}>
                     당신만의 <span className={style.pink}>&nbsp;취미</span>를 찾아보세요!
                 </div>
-                <form className={style.hobbyGet}>
-                    <select className={style.hobbyAbility}>
+                <form className={style.hobbyGet} onSubmit={linkSubmitHobby}>
+                    <select className={style.hobbyAbility} onChange={(e) => setHobbyAbility(e.target.value)} required>
                         <option value="" disabled selected>
                             신체적 특성
                         </option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
+                        <option value={0}>비장애인</option>
+                        <option value={1}>장애인</option>
                     </select>
 
-                    <select className={style.hobbyBudget}>
+                    <select className={style.hobbyBudget}  onChange={(e) => setHobbyBudget(e.target.value)} required>
                         <option value="" disabled selected>
                             사용 가능한 예산
                         </option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
+                        <option value={0}>0~100,000</option>
+                        <option value={1}>100,000~400,000</option>
+                        <option value={2}>400,000~1,000,000</option>
+                        <option value={3}>1,000,000~</option>
                     </select>
 
-                    <select className={style.hobbyLevel}>
+                    <select className={style.hobbyLevel}  onChange={(e) => setHobbyLevel(e.target.value)} required>
                         <option value="" disabled selected>
                             난이도
                         </option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
+                        <option value={0}>쉬움</option>
+                        <option value={1}>좀 쉬움</option>
+                        <option value={2}>평범</option>
+                        <option value={3}>좀 어려움</option>
+                        <option value={4}>어려움</option>
                     </select>
 
-                    <select className={style.hobbyTendency}>
+                    <select className={style.hobbyTendency} onChange={(e) => setHobbyTendency(e.target.value)} required>
                         <option value="" disabled selected>
                             성향
                         </option>
-                        <option value="1">1</option>
-                        <option value="2">2</option>
-                        <option value="3">3</option>
+                        <option value={0}>내향적</option>
+                        <option value={1}>외향적</option>
                     </select>
 
-                    <input type="submit" value="추천받기" className={style.submit} onClick={()=>linkSubmitHobby()} />
+                    <input type="submit" value="추천받기" className={style.submit}/>
                 </form>
             </div>
         </>


### PR DESCRIPTION
## 이슈
- #115 

## 📁 작업 파일
![image](https://github.com/user-attachments/assets/ab915210-3199-4a6c-abc3-6cfc8286e03d)

## 📝작업 내용
- 취미 게시판 맞춤형 취미 추천 페이지 로직 설정
  - 넘겨줄 값을 state로 지정, 쿼리스트링 결과 페이지로 넘겨줌
  - 핸들러를 추가하여 선택시  값을 넘겨주게 설정


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/4ef65196-9e6e-4168-9b33-8d627ad4ff2c)
![image](https://github.com/user-attachments/assets/9b0010d7-c6b0-4360-abc4-d4b9b1765317)
![image](https://github.com/user-attachments/assets/626807ec-8b98-464e-9330-67b3c5ad1598)


## 🚨수정 필요 내용
- 
