### PR TITLE
[feature/frontend-125/hobbyboard_hobbytag/request-api] 취미 게시판 취미 카테고리 페이지 Rest api 호출

### DIFF
--- a/senials_frontend/package.json
+++ b/senials_frontend/package.json
@@ -23,7 +23,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "proxy": "http://localhost:8080",
+  "proxy": "http://localhost:8081",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/senials_frontend/src/layouts/Header.js
+++ b/senials_frontend/src/layouts/Header.js
@@ -19,7 +19,7 @@ const Header = () => {
 
     //취미 목록 페이지 이동 이벤트
     const linkHobby=()=>{
-        navigate('/hobby-board');
+        navigate('/hobby-tag');
     }
 
     // 마이페이지 이동 이벤트

--- a/senials_frontend/src/pages/hobby/HobbyTagBoard.js
+++ b/senials_frontend/src/pages/hobby/HobbyTagBoard.js
@@ -1,16 +1,36 @@
-import React from 'react';
+import React,{useState, useEffect} from 'react';
 import styles from './HobbyBoard.module.css';
+import ctr from '../common/MainVer1.module.css';
 import { useNavigate } from 'react-router-dom';
+import { useSelector, useDispatch } from "react-redux";
+import axios from 'axios';
+import { setHobbyTop3Card } from '../../redux/hobbySlice';
+import { setCategories } from '../../redux/categorySlice.js';
 
-const top3List = [
-    { hobby: { number: 23, percentage: 63, name: "축구" } },
-    { hobby: { number: 33, percentage: 33, name: "농구" } },
-    { hobby: { number: 22, percentage: 22, name: "배드민턴" } }
-  ];
 
 function HobbyBoardPost() {
 
+    const dispatch=useDispatch();
     const navigate = useNavigate();
+
+    const top3List=useSelector((state=>state.hobbyTop3List));
+
+    useEffect(() => {
+        //취미 top3 조회
+        axios.get('/hobby-board/top3')
+        .then((response) => {
+            dispatch(setHobbyTop3Card(response.data.results.hobby));
+        })
+        .catch((error) => console.error(error));
+
+        //카테고리 조회
+        axios.get('/categories')
+        .then(result => {
+            dispatch(setCategories(result.data.results.categories));
+        })
+
+    }, [dispatch]);
+
 
     //취미 상세 페이지 이동 이벤트
     const linkHobbyDetail = (hobbyNumber) => {
@@ -25,10 +45,11 @@ function HobbyBoardPost() {
     return (
         <div className={styles.page}>
             <div className={styles.title}>👑 <span style={{ color: "#FF5391" }}>인기</span> TOP3</div>
+            <button className={`${ctr.whiteBtn} ${ctr.mlAuto}`} onClick={() => linkHobby()}>전체보기</button>
             <div className={styles.top3List}>
             
             {top3List.map((item,index) => {
-                return <HobbyCard key={index} hobby={item.hobby} linkHobby={linkHobbyDetail}/>
+                return <HobbyCard key={index} hobby={item} linkHobby={linkHobbyDetail}/>
             })}
     
             </div>
@@ -38,62 +59,77 @@ function HobbyBoardPost() {
                     카테고리
                 </span>
             </div>
-            <div>
-                <div className={styles.sort}>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    
-                </div>
-                <div className={styles.sort}>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                </div>
-                <div className={styles.sort}>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                    <Category  linkHobbyCategory={linkHobby}/>
-                </div>
+              <div className={`${ctr.ctgrRow}`}>
+                <Category navigate={navigate}/>
             </div>
         </div>
     );
 }
 
-function HobbyCard({hobby,linkHobby}){
+function HobbyCard({ hobby,linkHobby }){
     return(
-        <div className={styles.top3}  onClick={()=>linkHobby(hobby.number)}>
-                    <img src='/img/sampleImg3.png' className={styles.top3Img} alt="농구" />
-                    <div className={styles.top3Name}>{hobby.name}</div>
-                    <div className={styles.thirdFont}>선호도 : {hobby.percentage}%</div>
+        <div className={styles.top3} onClick={()=>linkHobby(hobby.hobbyNumber)}>
+                    <img src={`/img/hobbyboard/${hobby.hobbyNumber}`} className={styles.top3Img} alt="농구" />
+                    <div className={styles.top3Name}>{hobby.hobbyName}</div>
+                    <div className={styles.th}>선호도 : {setPercentage(hobby.rating)}%</div>
 
                     <div className={styles.progressBarContainer}>
                         <div
                             className={styles.progressBar}
-                            style={{ width: `${hobby.percentage}%` }}
+                            style={{ width: `${setPercentage(hobby.rating)}%` }}
                         ></div>
                     </div>
                 </div>
     );
 }
 
-function Category({linkHobby}) {
+// 카테고리 카드
+function Category({ navigate }) {
+
+    let categories = useSelector((state) => state.categories);
+    let length = categories.length;
+    let maxLength = 5;
+
     return (
-            <div className={styles.ctgrContainer} onClick={()=>linkHobby()}>
-                <div style={{backgroundImage: 'url(/img/sampleImg.png)', 
-                    backgroundSize: 'cover', backgroundPosition: 'center',
-                    border: '1px solid grey', width:'232px', height:'122px', borderColor: '#c7c7c7',
-                    borderRadius: '10px', display: 'flex', flexDirection: 'column', justifyContent: 'flex-end'}}>
-                    <span className={`${styles.ctgrText} ${styles.thirdFont}`}>카테고리</span>
-                </div>
+        <>
+        {
+            categories.map((category, idx) => {
+                
+
+                return (
+                    <div key={`categoryCard${idx}`} className={ctr.ctgrContainer} onClick={() => {navigate(`/hobby/board?category=${category.categoryNumber}`)}}>
+                        <div className={`${ctr.ctgrImage}`} style={{backgroundImage: `url(/img/category/${category.categoryNumber})`}}>
+                            <span className={`${ctr.ctgrText} ${ctr.thirdFont}`}>{category.categoryName}</span>
+                        </div>
+                    </div>
+                )
+            })
+        }
+        {
+            length % maxLength != 0 ?
+            Array.from({length: maxLength - (length % maxLength)}).map((_, i) => {
+                return <div key={`emptyCtgr${i}`} className={`${ctr.emptyCtgrContainer}`} />
+            })
+            :
+            null
+        }
+        {
+            length === 0 ?
+            // 결과 없음 안내
+            <div className={`${ctr.flexCenter} ${ctr.fullWidth}`}>
+                <span className={`${ctr.noSearchResult}`}>서비스 준비 중</span>
             </div>
+            :
+            null
+        }
+        </>
     )
+
+}
+
+function setPercentage(rating){
+    
+    return Math.ceil(rating*20);
 }
 
 export default HobbyBoardPost;


### PR DESCRIPTION
## 이슈
- #125 

## 📁 작업 파일
![image](https://github.com/user-attachments/assets/c7f919d9-26d1-4e43-9e88-27b102742e2e)
![image](https://github.com/user-attachments/assets/cae2d9bb-f871-46cf-9397-edebecb63f34)

## 📝작업 내용
- 취미 게시판 취미 카테고리 페이지 Rest api 호출
  - 인기 top3 취미 조회 rest api 호출
  - 카테고리 조회 rest api 호출
  - header 취미 페이지 연결 변


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/37d20c61-dc65-481b-80f8-545ff2e4143a)
![image](https://github.com/user-attachments/assets/a8a60b13-7e33-45be-b93e-e82fe75b9fc8)
![image](https://github.com/user-attachments/assets/1a8d0d03-6f15-40e5-8bdd-b4c6626f0280)


## 🚨수정 필요 내용
- 
