### PR TITLE
[feature/frontend-128/search-whole/request-api] 검색 키워드를 통해 취미,모임 결과 조회 Rest api 호출

### DIFF
--- a/senials_frontend/src/layouts/Header.js
+++ b/senials_frontend/src/layouts/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React,{useState} from 'react';
 import styles from './Header.module.css'
 import {FaAngleLeft, FaBell, FaSearch} from "react-icons/fa";
 import { useNavigate } from 'react-router-dom';
@@ -37,15 +37,33 @@ const Header = () => {
         navigate('/login');
     }
 
+    //키워드 입력 후 페이지 이동
+    const [keyword, setKeyword] = useState('');
+
+    //키워드 읽기
+    const handleInputChange = (e) => {
+        setKeyword(e.target.value);
+    };
+
+    const linkSearch = (e) => {
+        e.preventDefault();  
+        if (keyword.trim()) {
+            navigate(`/search-whole?keyword=${encodeURIComponent(keyword)}`);
+        }else{
+            alert("빈 상태로 검색을 진행할 순 없습니다.")
+        }
+    };
+   
+
     return (
         <>
         <div className={styles.line}></div>
         <div className={styles.header}>
-            <img src='/img/Logo.png' alt='Logo' onClick={()=>linkMain()} />
+            <img src='/img/Logo.png' alt='Logo'/>
             <img src='/img/LogoText.png' alt='Logo Text' onClick={()=>linkMain()}/>
 
-            <form className={styles.searchBox}>
-                <input type="text" placeholder='찾고싶은 모임이나 취미를 검색해보세요!'/>
+            <form className={styles.searchBox} onSubmit={linkSearch}>
+                <input type="text" placeholder='찾고싶은 모임이나 취미를 검색해보세요!' value={keyword}  onChange={handleInputChange}/>
                 <button type="submit" className={styles.searchButton}><FaSearch size={20}/></button>
             </form>
 

--- a/senials_frontend/src/pages/search/SearchWhole.js
+++ b/senials_frontend/src/pages/search/SearchWhole.js
@@ -1,165 +1,241 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import axios from 'axios';
 
 // CSS
 import styles from '../common/MainVer1.module.css';
 
-const testArray4 = [{number: 1}, {number: 2}, {number: 3}, {number: 4}];
-const testArray5 = [{number: 1}, {number: 2}, {number: 3}, {number: 4}, {number: 5}]
-const testArray6 = [{number: 1}, {number: 2}, {number: 3}, {number: 4}, {number: 5}, {number: 6}]
-
-
 function SearchWhole() {
-
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
 
-    const [tarr, setTarr] = useState([...testArray6]);
-
     const keyword = searchParams.get("keyword");
 
-    const testLoad = () => {
-        setTarr(prev => [...prev, {number: 5}]);
-    }
+    const [hobbyList, setHobbyList] = useState([]);
+    const [partyList, setPartyList] = useState([]);
+    const [hobbyPage, setHobbyPage] = useState(0);
+    const [partyPage, setPartyPage] = useState(0);
+    const [isInitialLoad, setIsInitialLoad] = useState(true); // 기존 상태 유지
+    const [hasMoreParty, setHasMoreParty] = useState(true); // 더보기 여부
+    const [hasMoreHobby, setHasMoreHobby] = useState(true); // 더보기 여부
+
+    // useEffect로 데이터 가져오기
+    useEffect(() => {
+        const fetchInitialData = async () => {
+            try {
+                const [partyResponse, hobbyResponse] = await Promise.all([
+                    axios.get(`search-whole/party?keyword=${keyword}&page=0&size=4`),
+                    axios.get(`search-whole/hobby?keyword=${keyword}&page=0&size=4`),
+                ]);
+                setPartyList(partyResponse.data.results.partyBoardDTOForCardList);
+                setHobbyList(hobbyResponse.data.results.hobbyCardDTOList);
+                setHasMoreParty(partyResponse.data.results.partyBoardDTOForCardList.length === 4);
+                setHasMoreHobby(hobbyResponse.data.results.hobbyCardDTOList.length === 4);
+                setIsInitialLoad(false); // 초기 로드 완료
+            } catch (error) {
+                console.error("초기 데이터 로드 실패", error);
+            }
+        };
+
+        fetchInitialData();
+    }, [keyword]); // keyword가 변경될 때마다 초기 데이터 로드
+
+    // "더보기" 클릭 시 데이터 추가 로드
+    const nextPartyList = async () => {
+        if (!hasMoreParty) return; // 더이상 데이터가 없으면 리턴
+        try {
+            const nextPage = partyPage + 1;
+            const response = await axios.get(`search-whole/party?keyword=${keyword}&page=${nextPage}&size=4`);
+            const newPartyList = response.data.results.partyBoardDTOForCardList;
+            setPartyList((prevList) => [...prevList, ...newPartyList]);
+            setPartyPage(nextPage);
+            // 새로운 데이터가 4개 이하이거나 비어있으면 더보기 버튼 숨기기
+            setHasMoreParty(newPartyList.length === 4);
+        } catch (error) {
+            console.error("모임 데이터 로드 실패", error);
+        }
+    };
+
+    const nextHobbyList = async () => {
+        if (!hasMoreHobby) return; // 더이상 데이터가 없으면 리턴
+        try {
+            const nextPage = hobbyPage + 1;
+            const response = await axios.get(`search-whole/hobby?keyword=${keyword}&page=${nextPage}&size=4`);
+            const newHobbyList = response.data.results.hobbyCardDTOList;
+            setHobbyList((prevList) => [...prevList, ...newHobbyList]);
+            setHobbyPage(nextPage);
+            // 새로운 데이터가 4개 이하이거나 비어있으면 더보기 버튼 숨기기
+            setHasMoreHobby(newHobbyList.length === 4);
+        } catch (error) {
+            console.error("취미 데이터 로드 실패", error);
+        }
+    };
 
     const linkHobby = (hobbyNumber) => {
         navigate(`/hobby/${hobbyNumber}`);
-    }
+    };
 
     const linkParty = (partyNumber) => {
         navigate(`/party/${partyNumber}`);
-    }
+    };
+
+    // 그리드에서 한 줄에 들어갈 카드 개수
+    const maxLength = 4;
+
+    // 모임 게시판과 취미 게시판 각각 검색 결과가 비어있는지 확인
+    const isPartyEmpty = partyList.length === 0;
+    const isHobbyEmpty = hobbyList.length === 0;
 
     return (
         <div className={styles.centerContainer}>
             <div className={styles.separator}>
                 <span className={`${styles.firstFont}`}>
-                    '<span className={styles.pointColor}>&nbsp;{ keyword }&nbsp;</span>'의 검색 결과
+                    '<span className={styles.pointColor}>&nbsp;{keyword}&nbsp;</span>'의 검색 결과
                 </span>
             </div>
 
-            {/* 모임 검색결과 출력 영역 */}
+            {/* 모임 게시판 */}
             <div className={styles.separator}>
                 <span className={`${styles.firstFont}`}>
                     모임 게시판
                 </span>
             </div>
             <hr />
-            <div className={`${styles.separatorContent}`}>
-                {
-                    tarr.map((party, idx) => {
-                        return (
-                            <PartyCard key={`partyCard${idx}`} party={party} linkParty={linkParty}/>
-                        )
-                    })
-                }
-                {
-                    <EmptyCards length={tarr.length} maxLength={4} />
-                }
-            </div>
-            <div className={`${styles.flexCenter} ${styles.marginBottom}`}>
-                <span className={`${styles.commonBtn}`} onClick={testLoad}>더보기</span>
-            </div>
+            {isPartyEmpty ? (
+                <div className={styles.flexCenter}>
+                    <span className={`${styles.noSearchResult}`}>모임 게시판에 대한 검색결과가 존재하지 않습니다.</span>
+                </div>
+            ) : (
+                <div className={`${styles.separatorContent}`}>
+                    {partyList.map((party, index) => (
+                        <PartyCard key={index} party={party} linkParty={linkParty} />
+                    ))}
+                    {/* 빈 카드로 그리드 맞추기 */}
+                    <EmptyCards length={partyList.length} maxLength={maxLength} />
+                    {hasMoreParty && (
+                        <div style={{ margin: 'auto' }} className={`${styles.flexCenter} ${styles.marginBottom}`}>
+                            <span className={`${styles.commonBtn}`} onClick={nextPartyList}>더보기</span>
+                        </div>
+                    )}
+                </div>
+            )}
 
-            {/* 취미 검색결과 출력 영역 */}
+            {/* 취미 게시판 */}
             <div className={styles.separator}>
                 <span className={`${styles.firstFont}`}>
                     취미 게시판
                 </span>
             </div>
             <hr />
-            <div className={`${styles.separatorContent}`}>
-                {testArray4.map((hobby, idx) => {
-                    return (
-                        <HobbyCard key={`hobbyCard${idx}`} hobby={hobby} linkHobby={linkHobby}/>
-                    )
-                })}
-            </div>
-            <div className={`${styles.flexCenter} ${styles.marginBottom}`}>
-                <span className={`${styles.commonBtn}`}>더보기</span>
-            </div>
-
-            {/* 검색결과 없음 안내 */}
-            {/* <div className={styles.flexCenter}>
-                <span className={`${styles.noSearchResult}`}>검색결과가 존재하지 않습니다.</span>
-            </div> */}
+            {isHobbyEmpty ? (
+                <div className={styles.flexCenter}>
+                    <span className={`${styles.noSearchResult}`}>취미 게시판에 대한 검색결과가 존재하지 않습니다.</span>
+                </div>
+            ) : (
+                <div className={`${styles.separatorContent}`}>
+                    {hobbyList.map((hobby, index) => (
+                        <HobbyCard key={index} hobby={hobby} linkHobby={linkHobby} />
+                    ))}
+                    {/* 빈 카드로 그리드 맞추기 */}
+                    <EmptyCards length={hobbyList.length} maxLength={maxLength} />
+                    {hasMoreHobby && (
+                        <div style={{ margin: 'auto' }} className={`${styles.flexCenter} ${styles.marginBottom}`}>
+                            <span className={`${styles.commonBtn}`} onClick={nextHobbyList}>더보기</span>
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
-    )
+    );
 }
 
 // 일반 별점 컴포넌트
-function Rate() {
+function Rate({averageRating}) {
+
+    let filled = parseInt(averageRating);
+    let halfFilled = averageRating * 100 % 100;
+    let unfilled = parseInt(5 - averageRating);
+
     return (
         <div className={`${styles.rateInfo}`}>
-            <div className={`${styles.baseStar}`}>
-                <div className={`${styles.filledStar}`}></div>
-            </div>
-            <div className={`${styles.baseStar}`}>
-                <div className={`${styles.filledStar}`}></div>
-            </div>
-            <div className={`${styles.baseStar}`}>
-                <div className={`${styles.filledStar}`}></div>
-            </div>
-            <div className={`${styles.baseStar}`}>
-                <div className={`${styles.filledStar}`}></div>
-            </div>
-            <div className={`${styles.baseStar}`}>
-                <div className={`${styles.halfStar}`} style={{width: '30%', marginRight: '70%'}}></div>
-            </div>
+            {
+                Array.from({length: filled}).map((_, idx) => {
+                    return (
+                        <div key={`filledStar${idx}`} className={`${styles.baseStar}`}>
+                            <div className={`${styles.filledStar}`}></div>
+                        </div>
+                    )
+                })
+            }
+            {
+                halfFilled > 0 ?
+                    <div className={`${styles.baseStar}`}>
+                        <div className={`${styles.halfStar}`} style={{width: `${halfFilled}%`, marginRight: `${100 - halfFilled}%`}}></div>
+                    </div>
+                :
+                    null
+            }
+            {
+                Array.from({length: unfilled}).map((_, idx) => {
+                    return (
+                        <div key={`unfilledStar${idx}`} className={`${styles.baseStar}`} />
+                    )
+                })
+            }
         </div>
     )
 }
 
 // 줄 맞춤용 빈 카드 생성 컴포넌트
-function EmptyCards({length, maxLength}) {
+function EmptyCards({ length, maxLength }) {
     const arr = [];
-    if(length % maxLength != 0) {
+    if (length % maxLength !== 0) {
         const cnt = maxLength - (length % maxLength);
-        for(let i = 0; i < cnt; i++) {
-            arr.push(<div className={`${styles.emptyCardContainer}`} key={`emptyCard${i}`} />)
+        for (let i = 0; i < cnt; i++) {
+            arr.push(<div className={`${styles.emptyCardContainer}`} key={`emptyCard${i}`} />);
         }
     }
     return (
         <>
-            { arr }
+            {arr}
         </>
-    )
+    );
 }
 
 // 모임 카드
-function PartyCard({party, linkParty}) {
-  return (
-    <div className={styles.cardContainer} onClick={() => linkParty(party.number)}>
-        <div className={styles.cardImage} style={{backgroundImage: 'url(/image/cat.jpg)'}}>
-            <img className={styles.imgHeart} src='/image/unfilledHeart.svg'/>
+function PartyCard({ party, linkParty }) {
+    return (
+        <div className={styles.cardContainer} onClick={() => linkParty(party.partyBoardNumber)}>
+            <div className={styles.cardImage} style={{ backgroundImage: `url(/img/partyboard/${party.partyBoardNumber}/thumbnail/${party.firstImage})` }}>
+            </div>
+            <div className={`${styles.secondFont}`}>{party.partyBoardName}</div>
+            <div className={styles.rateInfo}>
+                <Rate averageRating={party.averageRating}/>
+            </div>
+            <div className={styles.memberInfo}>
+                <img src='/image/people.svg' style={{ width: '20px' }} />&nbsp;
+                <span className={`${styles.fourthFont}`}>{party.memberCount}</span>
+                {
+                    party.partyBoardStatus == 0 ?
+                    <span className={`${styles.openedParty} ${styles.thirdFont} ${styles.mlAuto}`}>모집중</span>
+                    :
+                    <span className={`${styles.closedParty} ${styles.thirdFont} ${styles.mlAuto}`}>모집완료</span>
+                }
+            </div>
         </div>
-        <div className={`${styles.secondFont}`}>농구 같이 할 사람~</div>
-        <div className={styles.rateInfo}>
-            <Rate />
-        </div>
-        <div className={styles.memberInfo}>
-            <img src='/image/people.svg' style={{width: '20px'}}/>&nbsp;
-            <span className={`${styles.fourthFont}`}>10명</span>
-            <span className={`${styles.openedParty} ${styles.thirdFont} ${styles.mlAuto}`}>모집중</span>
-        </div>
-    </div>
-  )
+    );
 }
 
 // 취미 카드
-function HobbyCard({hobby, linkHobby}) {
+function HobbyCard({ hobby, linkHobby }) {
     return (
-      <div className={styles.cardContainer} onClick={() => linkHobby(hobby.number)}>
-          <div className={styles.cardImage} style={{backgroundImage: 'url(/image/1.jpg)'}} />
-          <div className={`${styles.secondFont} ${styles.flex}`}>
-            아웃도어
-            <span className={`${styles.separatorV}`}>
-                &nbsp;|&nbsp;
-            </span>
-            등산
+        <div className={styles.cardContainer} onClick={() => linkHobby(hobby.hobbyNumber)}>
+            <div className={styles.cardImage} style={{ backgroundImage: `url(/img/hobbyboard/${hobby.hobbyNumber})`}} />
+            <div className={`${styles.secondFont} ${styles.flex}`}>
+                {hobby.hobbyName}
+            </div>
         </div>
-      </div>
-    )
+    );
 }
 
 export default SearchWhole;


### PR DESCRIPTION
## 이슈
- #128 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/ea5f64c0-ef9d-436b-8105-ecae2fe7c8b6)
![image](https://github.com/user-attachments/assets/2ef488ac-19dd-4b59-8336-c4909b955a00)

## 📝작업 내용
- 검색 키워드를 통해 취미,모임 결과 조회 Rest api 호출
  - 헤더 키워드를 통해서 검색하는 로직 구성, 검색 키워드 예외처리
  - 취미이름과 모임이름을 기준으로 해당 키워드가 존재하는 취미,모임 조회 로직 구현
  - 더보기를 통해서 다음 api를 불러오는 페이지네이션 구현
  - 모임을 위한 별점 로직 구현
  - 빈 카드를 이용한 정렬 로직 구현
  - 데이터셋을 받아오긴 위한 변수 설정


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/b33a6a27-4db9-4c95-9c6b-58f2c14de217)
![image](https://github.com/user-attachments/assets/89c18681-f2a3-4d13-ae32-1b10dc134b0c)
![image](https://github.com/user-attachments/assets/bb19f82b-8c30-4af1-82c7-31e4dd5f0918)
![image](https://github.com/user-attachments/assets/64514b08-1279-4882-a150-d2515331091c)


## 🚨수정 필요 내용
- 
