### PR TITLE
[feature/frontend-153/admin/manage_suggestion] 관리자 건의 관리 페이지 레이아웃 설계

### DIFF
--- a/senials_frontend/src/App.js
+++ b/senials_frontend/src/App.js
@@ -36,7 +36,7 @@ import MypageMade from "./pages/mypage/MypageMade";
 import MypageParticipate from "./pages/mypage/MypageParticipate";
 import PartyMeetModify from "./pages/party/PartyMeetModify";
 import PartyReviewModify from "./pages/party/PartyReviewModify";
-import ManageUser from "./pages/admin/ManageUser";
+
 import Login from "./pages/login/Login";
 import Join from "./pages/login/Join";
 import Success from "./pages/login/Success";
@@ -44,6 +44,10 @@ import KakaoCallBack from "./pages/login/KakaoCallBack";
 
 import Suggestion from './pages/admin/Suggestion.js';
 import Report from './pages/admin/ReportComponent.js';
+import ManageUser from "./pages/admin/ManageUser";
+import ManageReport from './pages/admin/ManageReport.js';
+import ManageSuggestion from './pages/admin/ManageSuggestion.js';
+
 
 function App() {
     return (
@@ -62,7 +66,7 @@ function App() {
                     {/*test 성공페이지*/}
                     <Route path="success" element={<Success />} />
 
-                    {/* 신고하기 */}
+                    {/* 신고페이지지 */}
                     <Route path="report" element={<Report />} />
 
                     {/*마이페이지*/}
@@ -135,16 +139,15 @@ function App() {
                             {/* 모임 멤버 전체보기*/}
                             <Route path="members" element={<MypageMember />} />
                         </Route>
-                       
-
                     </Route>
-
-
-
                 </Route>
                 <Route path="admin">
                     {/*관리자페이지-사용자 관리*/}
                     <Route path="manage-user" element={<ManageUser/>}/>
+                    {/*관리자페이지-신고 관리*/}
+                    <Route path="manage-report" element={<ManageReport/>}/>
+                    {/*관리자페이지-건의 관리*/}
+                    <Route path="manage-suggestion" element={<ManageSuggestion/>}/>
                 </Route>
             </Routes>
             

--- a/senials_frontend/src/pages/admin/ManageSuggestion.js
+++ b/senials_frontend/src/pages/admin/ManageSuggestion.js
@@ -1,0 +1,72 @@
+import React,{useEffect, useState} from 'react';
+import styles from './Admin.module.css';
+import {useDispatch,userSelector, useSelector} from "react-redux";
+
+
+
+
+let userData={name:'김상익',title:'스퀴시라는 취미를 추가해주세요',kind:'취미 추가'}
+
+
+function ManageSuggestion(){
+
+    let state=useSelector((state)=>state)
+    let dispatch=useDispatch()
+
+
+    return(
+        <div>
+            <div className={styles.adminHeader}>
+                <img className={styles.adminLogo} src='/img/adminLogo.png'/>
+            </div>
+
+            <div className={styles.adminBody}>
+                <div className={styles.nav}>
+                    <div className={styles.navButton}><img src='/img/User.png'/>사용자 관리</div>
+                    <div className={styles.navButton}><img src='/img/Bell.png'/>신고 관리</div>
+                    <div className={styles.navButton}><img src='/img/BookOpen.png'/>게시글 관리</div>
+                    <div className={styles.navButton}><img src='/img/Bookmark.png'/>카테고리 관리</div>
+                    <div className={styles.navButton}><img src='/img/checkSquare.png'/>후기 관리</div>
+                    <div className={styles.navButton}><img src='/img/GitCommit.png'/>트래픽관리 관리</div>
+                    <div className={styles.navButton}><img src='/img/Users.png'/>건의 내역관리 관리</div>
+                </div>
+                <div className={styles.mainBody}>
+                    <div className={styles.mainTitle}>
+                        건의 관리
+                    </div>
+                    
+                    <div className={styles.mainDetail}>
+                    <div><input className={styles.searchBox} placeholder='검색'></input></div>
+                    <br/>
+                    <br/>
+                        <div className={styles.mainSubtitle}>
+                            <span>사용자</span>
+                            <span>건의 제목</span>
+                            <span>분류</span>
+                     
+                        </div>
+                        <hr/>
+                        <div className={styles.mainBox}>
+                        <UserData/>
+                        <UserData/>
+                        <UserData/>
+                        </div>
+                    </div>
+                </div>
+              
+            </div>
+        </div>
+    )
+}
+
+function UserData(){
+    return(
+        <div className={styles.mainSubtitle}>
+                <span>{userData.name}</span>
+                <span>{userData.title}</span>
+                <span>{userData.kind}</span>
+        
+        </div>
+    );
+}
+export default ManageSuggestion;


### PR DESCRIPTION
## 이슈
- #153 

## 📁 작업 파일
![image](https://github.com/user-attachments/assets/c8e8e25d-116a-42e9-9277-a7878ddde730)


## 📝작업 내용
- 관리자 건의 관리 페이지 레이아웃 설계
  - 관리자 건의 관리 페이지 레이아웃 구성
  - 라우트 연결 재설정


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/14a2bd02-c404-4633-ae34-62c95dacc151)
![image](https://github.com/user-attachments/assets/b9b81556-7096-4ea2-9a97-cdfbbfff5592)


## 🚨수정 필요 내용
- 
