### PR TITLE
[feature/frontend-165/admin_managesuggection/rest-api] 관리자 건의 조회 페이지 건의 사항 조회 Rest api 호출, 구조 만들기 

### DIFF
--- a/senials_frontend/package.json
+++ b/senials_frontend/package.json
@@ -44,5 +44,5 @@
   "devDependencies": {
     "web-vitals": "^4.2.4"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:8081"
 }

--- a/senials_frontend/src/App.js
+++ b/senials_frontend/src/App.js
@@ -48,6 +48,7 @@ import ManageUser from "./pages/admin/ManageUser";
 import ManageReport from './pages/admin/ManageReport.js';
 import ManageSuggestion from './pages/admin/ManageSuggestion.js';
 import ManageCateogry from './pages/admin/ManageCateogry.js';
+import SuggestionDetail from './pages/admin/SuggestionDetail.js';
 
 
 function App() {
@@ -108,8 +109,10 @@ function App() {
                     <Route path="/hobby-review" element={<HobbyReview/>}/>
                     {/*취미 게시판 후기 수정 */}
                     <Route path="/hobby-review-modify" element={<HobbyReviewModify/>}/>
-                    {/* 취미 게시판 건의의 */}
+                    {/* 취미 게시판 건의 */}
                     <Route path="/suggestion" element={<Suggestion/>}/>
+                    {/* 건의 readOnly */}
+                    <Route path="/suggestionDetail" element={<SuggestionDetail/>}/>
 
                     <Route path='party'>
                         {/* 모임 작성 */}

--- a/senials_frontend/src/App.js
+++ b/senials_frontend/src/App.js
@@ -109,7 +109,7 @@ function App() {
                     {/*취미 게시판 후기 수정 */}
                     <Route path="/hobby-review-modify" element={<HobbyReviewModify/>}/>
                     {/* 취미 게시판 건의의 */}
-                    <Route path="suggestion" element={<Suggestion/>}/>
+                    <Route path="/suggestion" element={<Suggestion/>}/>
 
                     <Route path='party'>
                         {/* 모임 작성 */}

--- a/senials_frontend/src/pages/admin/ManageSuggestion.js
+++ b/senials_frontend/src/pages/admin/ManageSuggestion.js
@@ -45,7 +45,7 @@ function ManageSuggestion(){
         })
     },[]);
 
-    //건의 글 상세보기기
+    //건의 글 상세보기
     const linkSuggestion=(suggestionNumber)=>{
         navigate(`/suggestionDetail?suggestionNumber=${suggestionNumber}`);
     };

--- a/senials_frontend/src/pages/admin/ManageSuggestion.js
+++ b/senials_frontend/src/pages/admin/ManageSuggestion.js
@@ -1,7 +1,8 @@
 import React,{useEffect, useState} from 'react';
 import styles from './Admin.module.css';
-import {useDispatch,userSelector, useSelector} from "react-redux";
 import AdminNav from './AdminNav.js';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 
 
@@ -10,9 +11,44 @@ let userData={name:'김상익',title:'스퀴시라는 취미를 추가해주세�
 
 function ManageSuggestion(){
 
-    let state=useSelector((state)=>state)
-    let dispatch=useDispatch()
+    const navigate= useNavigate();
 
+    const [suggestionList,setSuggestionList]=useState([]);
+
+    const[searchText, setSearchText]=useState("");
+    const[filterList,setFilterList]=useState([]);
+
+    //검색 텍스트가 변화할 때마다 리스트 내용 변환
+    useEffect(() => {
+        const filtered = suggestionList.filter(item => 
+            item.suggestionTitle.includes(searchText)
+        );
+        setFilterList(filtered);
+    }, [searchText, suggestionList]); 
+
+    //검색 텍스트 값 변환 핸들러
+    const handleSearchChange = (e) => {
+        setSearchText(e.target.value);
+    };
+
+
+    useEffect(()=>{
+        axios.get(`/suggestion`)
+        .then((response)=>{
+            //가장 최신 글이 위로 올라오게끔 변경
+            const sortedSuggestions = response.data.results.suggestionDTOList.sort((a, b) => {
+                const dateA = new Date(b.suggestionDate);
+                const dateB = new Date(a.suggestionDate);
+                return dateA - dateB;
+            });
+            setSuggestionList(sortedSuggestions);
+        })
+    },[]);
+
+    //건의 글 상세보기기
+    const linkSuggestion=(suggestionNumber)=>{
+        navigate(`/suggestionDetail?suggestionNumber=${suggestionNumber}`);
+    };
 
     return(
         <div>
@@ -28,7 +64,7 @@ function ManageSuggestion(){
                     </div>
                     
                     <div className={styles.mainDetail}>
-                    <div><input className={styles.searchBox} placeholder='검색'></input></div>
+                    <div><input className={styles.searchBox} placeholder='검색'  value={searchText} onChange={handleSearchChange}></input></div>
                     <br/>
                     <br/>
                         <div className={styles.mainSubtitle}>
@@ -40,9 +76,9 @@ function ManageSuggestion(){
                         </div>
                         <hr/>
                         <div className={styles.mainBox}>
-                        <UserData/>
-                        <UserData/>
-                        <UserData/>
+                        {filterList.map((item, index)=>(
+                            <UserData key={index} suggestion={item} linkSuggestion={linkSuggestion}/>
+                        ))}
                         </div>
                     </div>
                 </div>
@@ -52,14 +88,36 @@ function ManageSuggestion(){
     )
 }
 
-function UserData(){
+function UserData({suggestion,linkSuggestion}){
     return(
-        <div className={styles.mainSubtitle}>
-                <span>{userData.name}</span>
-                <span>{userData.title}</span>
-                <span>{userData.kind}</span>
-                <span>{userData.date}</span>
+        <div className={styles.mainSubtitle} onClick={()=>linkSuggestion(suggestion.suggestionNumber)}>
+                <span>{suggestion.userName}</span>
+                <span>{suggestion.suggestionTitle}</span>
+                <span>{convertSuggestionType(suggestion.suggestionType)}</span>
+                <span>{convertDate(suggestion.suggestionDate)}</span>
         </div>
     );
 }
+
+function convertSuggestionType(suggestionType){
+    switch(suggestionType){
+        case 0:
+            return "취미추가";
+        case 1:
+            return "버그제보";
+        default:
+            return "알수없음"
+    }
+
+}
+
+function convertDate(datetime){
+    const date = new Date(datetime); 
+    const year = date.getFullYear();
+    const month = (date.getMonth() + 1).toString().padStart(2, '0');
+    const day = date.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+
 export default ManageSuggestion;

--- a/senials_frontend/src/pages/admin/Suggestion.js
+++ b/senials_frontend/src/pages/admin/Suggestion.js
@@ -31,7 +31,7 @@ function Suggestion(){
         }
         try {
             const token = localStorage.getItem("token");
-            console.log(token);
+
             await axios.post(`/suggestion`, suggestionData, {
                 headers: {
                     'Authorization': token // JWT 토큰을 Authorization 헤더에 추가
@@ -40,7 +40,7 @@ function Suggestion(){
             alert('건의 요청이 완료되었습니다.');
             goBack();  
         } catch (error) {
-            alert('건의 요청청이 완료되지 않았습니다.');
+            alert('건의 요청이 완료되지 않았습니다.');
             console.error(error); // 오류 처리
         }
     };

--- a/senials_frontend/src/pages/admin/Suggestion.js
+++ b/senials_frontend/src/pages/admin/Suggestion.js
@@ -11,7 +11,6 @@ function Suggestion(){
     const[kind,setKind]=useState(0);
     const[title,setTitle]=useState('');
     const[detail,setDetail]=useState('');
-    const [date, setDate] = useState(new Date());
 
     // 이전 페이지로 돌아가기 이벤트
     const goBack = () => {
@@ -27,10 +26,10 @@ function Suggestion(){
             suggestionTitle:title,
             suggestionType:kind,
             suggestionDetail:detail,
-            suggestionDate:date
         }
         try {
             const token = localStorage.getItem("token");
+            console.log(suggestionData);
 
             await axios.post(`/suggestion`, suggestionData, {
                 headers: {

--- a/senials_frontend/src/pages/admin/Suggestion.js
+++ b/senials_frontend/src/pages/admin/Suggestion.js
@@ -1,8 +1,50 @@
-import React from 'react';
+import React,{useEffect, useState} from 'react';
 import styles1 from './Report.module.css';
 import styles2 from '../common/Common.module.css'
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 
 function Suggestion(){
+
+    const navigate=useNavigate();
+
+    const[kind,setKind]=useState(0);
+    const[title,setTitle]=useState('');
+    const[detail,setDetail]=useState('');
+    const [date, setDate] = useState(new Date());
+
+    // 이전 페이지로 돌아가기 이벤트
+    const goBack = () => {
+        navigate(-1);
+    }
+    
+    // rest api 호출,제출 처리
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        // JSON 데이터 생성
+        const suggestionData={
+            suggestionTitle:title,
+            suggestionType:kind,
+            suggestionDetail:detail,
+            suggestionDate:date
+        }
+        try {
+            const token = localStorage.getItem("token");
+            console.log(token);
+            await axios.post(`/suggestion`, suggestionData, {
+                headers: {
+                    'Authorization': token // JWT 토큰을 Authorization 헤더에 추가
+                }
+            });
+            alert('건의 요청이 완료되었습니다.');
+            goBack();  
+        } catch (error) {
+            alert('건의 요청청이 완료되지 않았습니다.');
+            console.error(error); // 오류 처리
+        }
+    };
+
     return(
         <div className={styles1.container}>
             
@@ -10,7 +52,7 @@ function Suggestion(){
 
             <div className={styles1.marginBottom40}>
                 <span className={styles2.secondFont}>분류</span>
-                <select className={styles1.selectLine}>
+                <select className={styles1.selectLine} onChange={(e) => setKind(Number(e.target.value))}>
                     <option value="" disabled selected>건의 분류 선택</option>
                     <option value={0}>취미 추가 요청</option>
                     <option value={1}>버그 제보</option>
@@ -21,17 +63,17 @@ function Suggestion(){
 
             <div className={styles1.marginBottom40}>
                 <span className={styles2.secondFont}>제목</span>
-                <input className={styles1.inputLine} placeholder='건의 제목을 입력해 주세요!'></input>
+                <input className={styles1.inputLine} placeholder='건의 제목을 입력해 주세요!' onChange={(e) => setTitle(e.target.value)}></input>
             </div>
 
             <div className={styles1.marginBottom20}>
                 <div className={`${styles2.secondFont} ${styles1.marginBottom20}`}>내용</div>
-                <textarea className={styles1.textArea} placeholder='건의 내용을 입력해주세요!'></textarea>
+                <textarea className={styles1.textArea} placeholder='건의 내용을 입력해주세요!'onChange={(e) => setDetail(e.target.value)}></textarea>
             </div>
 
             <div className={`${styles1.floatRight}`}>
-                <button className={styles1.cancleButton}>취소</button>
-                <button className={styles1.submitButton}>제출</button>
+                <button className={styles1.cancleButton} onClick={goBack}>취소</button>
+                <button className={styles1.submitButton} onClick={handleSubmit}>제출</button>
             </div>
         </div>
         

--- a/senials_frontend/src/pages/admin/SuggestionDetail.js
+++ b/senials_frontend/src/pages/admin/SuggestionDetail.js
@@ -1,0 +1,85 @@
+import React,{useEffect, useState} from 'react';
+import styles1 from './Report.module.css';
+import styles2 from '../common/Common.module.css'
+import { useNavigate,useLocation } from 'react-router-dom';
+import axios from 'axios';
+
+function SuggestionDetail(){
+
+    const navigate=useNavigate();
+
+    const location = useLocation();
+    const queryParams = new URLSearchParams(location.search);
+    const suggestionNumber = queryParams.get('suggestionNumber');
+
+    const[kind,setKind]=useState(0);
+    const[title,setTitle]=useState('데이터 없음');
+    const[detail,setDetail]=useState('데이터 없음');
+
+    useEffect(() => {
+        if (suggestionNumber) {
+            axios.get(`/suggestion/${suggestionNumber}`)
+                .then((response) => {
+                    setKind(response.data.results.suggestionDTO.suggestionType);
+                    setTitle(response.data.results.suggestionDTO.suggestionTitle);
+                    setDetail(response.data.results.suggestionDTO.suggestionDetail);
+                })
+                .catch((error) => {
+                    console.error("API 호출 실패:", error);
+                });
+        }
+    }, [suggestionNumber]);
+
+    // 이전 페이지로 돌아가기 이벤트
+    const goBack = () => {
+        navigate(-1);
+    }
+
+    //삭제 이벤트
+    const deleteSuggetion = () => {
+        try {
+            axios.delete(`/suggestion/${suggestionNumber}`)
+                .then(() => {
+                    alert('해당 건의안은 삭제되었습니다.');
+                    navigate(-1);
+                })
+        } catch (error) {
+            alert("삭제 중 오류가 발생했습니다.");
+        }
+    }
+
+    return(
+        <div className={styles1.container}>
+            
+            <div className={`${styles2.firstFont} ${styles1.marginBottom40}`}><span className={styles2.pointColor}>건의</span>하기</div>
+
+            <div className={styles1.marginBottom40}>
+                <span className={styles2.secondFont}>분류</span>
+                <select className={styles1.selectLine}  value={kind} disabled>
+                    <option value={0}>취미 추가 요청</option>
+                    <option value={1}>버그 제보</option>
+                </select>
+            </div>
+
+            <br/>
+
+            <div className={styles1.marginBottom40}>
+                <span className={styles2.secondFont}>제목</span>
+                <input className={styles1.inputLine} value={title} readOnly></input>
+            </div>
+
+            <div className={styles1.marginBottom20}>
+                <div className={`${styles2.secondFont} ${styles1.marginBottom20}`}>내용</div>
+                <textarea className={styles1.textArea} value={detail} readOnly></textarea>
+            </div>
+
+            <div className={`${styles1.floatRight}`}>
+                <button className={styles1.cancleButton} onClick={deleteSuggetion}>삭제</button>
+                <button className={styles1.submitButton} onClick={goBack}> 확인</button>
+            </div>
+        </div>
+        
+    )
+}
+
+export default SuggestionDetail;

--- a/senials_frontend/src/pages/hobby/HobbyBoard.js
+++ b/senials_frontend/src/pages/hobby/HobbyBoard.js
@@ -65,8 +65,14 @@ function HobbyBoardPost() {
         navigate(0); 
     }
 
+    //건의 사항 추가 페이지 이동
     const linkSuggestion=()=>{
-        navigate(`/suggestion`);
+        const token = localStorage.getItem("token");
+        if (!token) {
+            navigate('/login'); // 토큰이 없으면 로그인 페이지로 리다이렉트
+        } else {
+            navigate(`/suggestion`);
+        }
     }
 
 

--- a/senials_frontend/src/pages/hobby/HobbyBoard.js
+++ b/senials_frontend/src/pages/hobby/HobbyBoard.js
@@ -65,6 +65,10 @@ function HobbyBoardPost() {
         navigate(0); 
     }
 
+    const linkSuggestion=()=>{
+        navigate(`/suggestion`);
+    }
+
 
     //검색 버튼 클릭시 목록 필터링 이벤트
     const textSearch=(e)=>{
@@ -96,7 +100,7 @@ function HobbyBoardPost() {
                 return <HobbyList key={index} hobby={item} linkHobbyDetail={linkHobbyDetail}/>
             })}
             
-            <button className={styles.suggestHobbyButton}>취미 추가 건의</button>
+            <button className={styles.suggestHobbyButton} onClick={linkSuggestion}>취미 추가 건의</button>
         </div>
     );
 }


### PR DESCRIPTION
## 이슈
- #165 


## 📁 작업 파일
![image](https://github.com/user-attachments/assets/e5f02733-6569-450e-aecd-dff87d7445fa)
![image](https://github.com/user-attachments/assets/00205aae-48dc-4af7-bd04-161cdc9fb628)

## 📝작업 내용
- 관리자 건의 조회 페이지 건의 사항 조회 Rest api 호출, 구조 만들기 
  - 건의안 상세 조회 페이지 생성 및 라우트 연결
  - 건의안 상세 조회 페이지 해당 건의안 내용 불러오는 rest api 호출, 삭제 rest api 호출
  - 관리자 건의 조회 페이지 rest api 작성
  - 검색바를 통해 제목을 기준으로 검색 가능 기능 추가
  - 데이터를 최신 데이터가 상단에 위치하게 정렬


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/a235cfe1-1687-4953-a8b5-dafe560a030f)
![image](https://github.com/user-attachments/assets/2dc47d0d-dce2-416a-9e14-da85f42c39f0)
![image](https://github.com/user-attachments/assets/fde8c73f-c607-4b39-b62c-75648e4b7c2c)
![image](https://github.com/user-attachments/assets/bc32c874-6bde-4cf2-8405-ea6d35a61a7f)


## 🚨수정 필요 내용
- 
