### PR TITLE
[feature/frontend-170/admin_managecategory/rest-api] 관리자 카테고리 관리 페이지 Rest api 호출, 구조 만들기

### DIFF
--- a/senials_frontend/src/pages/admin/ManageCateogry.js
+++ b/senials_frontend/src/pages/admin/ManageCateogry.js
@@ -1,13 +1,76 @@
 import React,{useEffect, useState} from 'react';
 import styles from './Admin.module.css';
-import {useDispatch,userSelector, useSelector} from "react-redux"
 import { useNavigate, useLocation } from 'react-router-dom';
 import AdminNav from './AdminNav.js';
-
-
-  
+import axios from 'axios';
+import { MdVisibility } from 'react-icons/md';
 
 function ManageCateogry(){
+
+    const[categoryList,setCatgoryList]=useState([]);
+    const[hobbyList,setHobbyList]=useState([]);
+
+    //카테고리 목록 조회
+    useEffect(() => {
+        axios.get(`/categories`)
+        .then((response) => {
+            setCatgoryList(response.data.results.categories);
+        })
+        .catch((error) => {
+            console.error('카테고리 목록 조회 에러', error);
+        });
+    }, []);
+
+      //취미 목록 조회
+      const handleChange = (e) => {
+        const categoryNumber=(e.target.value);
+        if(categoryNumber==0){
+            axios.get(`/hobby-board`)
+            .then((response)=>{
+                setHobbyList(response.data.results.hobby);
+               })
+               .catch((error)=>{
+                console.error('취미 목록 조회 에러', error);
+               })
+        }
+        axios.get(`/hobby-board/${categoryNumber}`)
+        .then((response)=>{
+         setHobbyList(response.data.results.hobby);
+        })
+        .catch((error)=>{
+         console.error('취미 목록 조회 에러', error);
+        })
+     };
+
+
+    const[searchText, setSearchText]=useState("");
+    const[filterList,setFilterList]=useState([]);
+
+    //로드시 처음 초기값 전체보기
+    useEffect(() => {
+        axios.get(`/hobby-board`)
+            .then((response) => {
+                const hobby = response.data.results.hobby;
+                setHobbyList(hobby); 
+                setFilterList(hobby);
+            })
+            .catch((error) => {
+                console.error('취미 목록 가져오기 실패:', error);
+            });
+        },[])
+
+    //검색 텍스트가 변화할 때마다 리스트 내용 변환
+    useEffect(() => {
+        const filtered = hobbyList.filter(item => 
+            item.hobbyName.includes(searchText)
+        );
+        setFilterList(filtered);
+    }, [searchText, hobbyList]); 
+
+      //검색 텍스트 값 변환 핸들러
+      const handleSearchChange = (e) => {
+        setSearchText(e.target.value);
+    };
     
     return(
         <div>
@@ -25,29 +88,31 @@ function ManageCateogry(){
                     <div className={styles.sub}>
                         <div className={styles.category}>
                             <span className={styles.subTitle}>카테고리 대분류</span>
-                            <select>
-                                <option>운동</option>
-                                <option>동운운</option>
+                            <select onChange={handleChange}>
+                                <option value={0}>전체보기</option>
+                                {categoryList.map((category)=>(
+                                      <option key={category.categoryNumber} value={category.categoryNumber}>{category.categoryName}</option>
+                                ))}
                             </select>
                         </div>
                         
 
                         <div className={styles.categoryMainDetail}>
                         <span className={styles.subTitle}>카테고리 소분류</span>
-                            <div><input className={styles.searchBox} placeholder='검색'></input></div>
+                            <div><input className={styles.searchBox} placeholder='검색' value={searchText} onChange={handleSearchChange}></input></div>
                             <br/>
                             <br/>
                                 <div className={styles.mainSubtitle}>
-                                    <input type='checkbox'></input>
+                                    <input type='checkbox' style={{visibility:'hidden'}}></input>
                                     <span>취미명</span>
                                     <span>간단한설명</span>
                                     <span>선호도</span>
                                 </div>
                                 <hr/>
                                 <div className={styles.mainBox}>
-                                <hobbyData/>
-                                <hobbyData/>
-                                <hobbyData/>
+                                {filterList.map((item,index)=>(
+                                    <HobbyData key={index} hobby={item}/>
+                                ))}
                                 </div>
                         </div>
 
@@ -64,17 +129,35 @@ function ManageCateogry(){
     )
 }
 
-function hobbyData(){
+function HobbyData({hobby,setPercentage}){
+
+    const [selectedHobby, setSelectedHobby] = useState(null);
+
+    const handleSelect = (hobbyNumber) => {
+        setSelectedHobby(hobbyNumber);
+    };
+
     return(
         <div className={styles.mainSubtitle}>
-                <input type='checkbox'></input>
-                <span>dd</span>
-                <span>dd</span>
-                <span>dd</span>
-                <span>dd</span>
-                <span>dd</span>
-                <span>Dd</span>
+
+                <input type="radio"
+                name="hobbyGroup"
+                value={hobby.hobbyNumber}
+                checked={selectedHobby === hobby.hobbyNumber}
+                onChange={() => handleSelect(hobby.hobbyNumber)}/>
+
+                <span>{hobby.hobbyName}</span>
+                <span className={styles.explain}>{hobby.hobbyExplain}</span>
+                <span>{setPercentage(hobby.rating)}%</span>
         </div>
     );
+
+
+    function setPercentage(rating){
+        
+        return Math.ceil(rating*20);
+    }
+
 }
+
 export default ManageCateogry;

--- a/senials_frontend/src/pages/admin/admin.module.css
+++ b/senials_frontend/src/pages/admin/admin.module.css
@@ -156,3 +156,9 @@
     border-radius: 10px;
     border:none;
 }
+
+.explain{
+    white-space: nowrap; 
+    overflow: hidden;
+    text-overflow: ellipsis; 
+}


### PR DESCRIPTION
## 이슈
- #170 

## 📁 작업 파일
![image](https://github.com/user-attachments/assets/63fb226d-87a2-48cd-9236-2e983fd95210)



## 📝작업 내용
- 관리자 카테고리 관리 페이지 Rest api 호출, 구조 만들기
  - 관리자 카테고리 관리 페이지 취미목록, 카테고리 조회 Rest api 호출
  - 관리 페이지 구조 설정 및 구성
  - 대분류를 기준으로 소분류도 같이 바뀌는 로직 구성
  - 취미명으로 검색 기능 구현


## 🖼️작업 완료 이미지 (완성된 페이지 전과 후 비교 및 코드 사진)
![image](https://github.com/user-attachments/assets/4686c630-b177-42e6-87ba-a2261d23c574)
![image](https://github.com/user-attachments/assets/6587e6db-422e-4899-ab0a-d7bb5a22b829)
![image](https://github.com/user-attachments/assets/4ad3d535-ac9e-4347-869b-4a5fea6f0ad2)
![image](https://github.com/user-attachments/assets/4a2ba807-9576-42f0-b356-a258305b0a6e)



## 🚨수정 필요 내용
- 
